### PR TITLE
Update Data_Integration_-_Accredited_Integrating_Authorities.html

### DIFF
--- a/Data_Integration_-_Accredited_Integrating_Authorities.html
+++ b/Data_Integration_-_Accredited_Integrating_Authorities.html
@@ -91,6 +91,16 @@
 <ul><li>Visit the CVDL web site at <a href="http://www2.health.vic.gov.au/about/reporting-planning-data/the-centre-for-victorian-data-linkage">health.vic.gov.au/about/reporting-planning-data/the-centre-for-victorian-data-linkage</a></li>
 <li>Email CVDL: cvdl@dhhs.vic.gov.au</li>
 <li>Visit: 50 Lonsdale Street, Melbourne, VIC 3000</li></ul>
+					
+<h1><span id="South_Australia_Northern_Territory_DataLink_(SA_NT_DataLink)"></span>South Australia Northern Territory DataLink (SA NT DataLink)</h1>
+<p><b>Date accredited:</b> 17 September 2019
+</p><p><b>Accreditation application summary:</b> South Australia Northern Territory DataLink (SA NT DataLink)
+</p><p><b>Accreditation application summary (pdf):</b> <a href="files/404">coming soon</a>
+</p><p><b>Contact details: </b>
+</p>
+<ul><li>Visit the SA NT DataLink web site at <a href="http://www.santdatalink.org.au">www.santdatalink.org.au</a></li>
+<li>Email SA NT DataLink: santdatalink@unisa.edu.au</li>
+<li>Visit: the SA NT DataLink Offices in Adelaide (South Australian Health Medical Research Institute [SAHMRI] building, North Terrace, Adelaide 5000) or Darwin (Level 2 Health House, Northern Territory Department of Health, 87 Mitchell Street, Darwin NT 0800)</li></ul>
 <p><br />
 </p>
 


### PR DESCRIPTION
A new Integrating Authority (SA NT DataLink) was accredited in September. Consequently, their application and contact details need to be included on this page.

If you could please update this page after ensuring the new content on this Integrating Authority is formatted consistently with the other entries, that would be much appreciated.